### PR TITLE
Python 3.11 / 2023 update

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ This repository holds the Grid Studies for Python:
 * [grid-studies-2-4.py](files/grid-studies-2-4.py)
 * [grid-studies-2-5.py](files/grid-studies-2-5.py)
 
-The latest release of this repository can be donwloaded [here](https://github.com/monome/grid-studies-python/releases).
+The latest release of this repository can be downloaded [here](https://github.com/monome/grid-studies-python/releases).
 
-The complete monome docs are hosted at [monome.org/docs/](https://monome.org/docs/) and  developed at [github.com/monome/docs](https://github.com/monome/docs).
+These files correspond to [this long-form walkthrough](https://monome.org/docs/grid/studies/python/) of scripting for grids + Python.
+
+The complete monome docs are hosted at [monome.org/docs/](https://monome.org/docs/) and developed at [github.com/monome/docs](https://github.com/monome/docs).

--- a/files/grid-studies-1.py
+++ b/files/grid-studies-1.py
@@ -4,7 +4,6 @@ import asyncio
 import monome
 
 class GridStudies(monome.GridApp):
-    
     def __init__(self):
         super().__init__()
 

--- a/files/grid-studies-1.py
+++ b/files/grid-studies-1.py
@@ -1,18 +1,17 @@
-#! /usr/bin/env python3
-
 import asyncio
 import monome
 
 class GridStudies(monome.GridApp):
+    
     def __init__(self):
         super().__init__()
 
     def on_grid_key(self, x, y, s):
         print("key:", x, y, s)
-        self.grid.led_level_set(x, y, s*15)
+        self.grid.led_level_set(x, y, s * 15)
 
-if __name__ == '__main__':
-    loop = asyncio.get_event_loop()
+async def main():
+    loop = asyncio.get_running_loop()
     grid_studies = GridStudies()
 
     def serialosc_device_added(id, type, port):
@@ -22,5 +21,8 @@ if __name__ == '__main__':
     serialosc = monome.SerialOsc()
     serialosc.device_added_event.add_handler(serialosc_device_added)
 
-    loop.run_until_complete(serialosc.connect())
-    loop.run_forever()
+    await serialosc.connect()
+    await loop.create_future()
+
+if __name__ == '__main__':
+    asyncio.run(main())

--- a/files/grid-studies-1.py
+++ b/files/grid-studies-1.py
@@ -1,3 +1,5 @@
+#! /usr/bin/env python3
+
 import asyncio
 import monome
 

--- a/files/grid-studies-2-1.py
+++ b/files/grid-studies-2-1.py
@@ -6,10 +6,10 @@ import monome
 class GridStudies(monome.GridApp):
     def __init__(self):
         super().__init__()
-
-    width = 0
-    height = 0
-    step = [[0 for col in range(16)] for row in range(16)]            
+        self.width = 0
+        self.height = 0
+        self.step = [[0 for col in range(16)] for row in range(16)]
+        self.play_task = asyncio.ensure_future(self.play())
 
     # when grid is plugged in via USB:
     def on_grid_ready(self):
@@ -17,6 +17,7 @@ class GridStudies(monome.GridApp):
         self.height = self.grid.height
         self.sequencer_rows = self.height-2
         self.connected = True
+        self.draw()
 
     # when grid is physically disconnected:
     def on_grid_disconnect(self, *args):
@@ -25,7 +26,7 @@ class GridStudies(monome.GridApp):
     async def play(self):
         while True:
             await asyncio.sleep(0.1)
-            
+
             self.draw()
 
     def on_grid_key(self, x, y, s):
@@ -36,16 +37,16 @@ class GridStudies(monome.GridApp):
 
     def draw(self):
         buffer = monome.GridBuffer(self.width, self.height)
-        
+
         # display steps
         for x in range(self.width):
             for y in range(self.sequencer_rows):
                 buffer.led_level_set(x, y, self.step[y][x] * 11)
-            
+
         # update grid
         if self.connected:
             buffer.render(self.grid)
-        
+
 async def main():
     loop = asyncio.get_running_loop()
     grid_studies = GridStudies()
@@ -56,8 +57,6 @@ async def main():
 
     serialosc = monome.SerialOsc()
     serialosc.device_added_event.add_handler(serialosc_device_added)
-
-    play_task = asyncio.create_task(grid_studies.play())
 
     await serialosc.connect()
     await loop.create_future()

--- a/files/grid-studies-2-1.py
+++ b/files/grid-studies-2-1.py
@@ -1,42 +1,66 @@
-#! /usr/bin/env python3
-
 import asyncio
 import monome
 
 class GridStudies(monome.GridApp):
+
+    global gridConnected
+    global firstConnection
+
     def __init__(self):
         super().__init__()
+    
+    # track connection status:
+    def connectGrid(state, self):
+        GridStudies.gridConnected = state
+        try:
+            GridStudies.firstConnection
+            GridStudies.firstConnection = False
+        except:
+            GridStudies.firstConnection = True
+            playTask = asyncio.create_task(self.play())
 
+    # when grid is plugged in via USB:
     def on_grid_ready(self):
-        self.step = [[0 for col in range(self.grid.width)] for row in range(6)]
+        global width
+        width = self.grid.width
+        global height
+        height = self.grid.height
+        global canvasFloor
+        canvasFloor = height-2
 
-        asyncio.async(self.play())
+        GridStudies.connectGrid(True, self)
+        if GridStudies.firstConnection:
+            self.step = [[0 for col in range(width)] for row in range(canvasFloor)]
+
+    # when grid is physically disconnected:
+    def on_grid_disconnect(self, *args):
+        GridStudies.connectGrid(False, self)
 
     async def play(self):
         while True:
-            self.draw()
-
             await asyncio.sleep(0.1)
-
-    def draw(self):
-        buffer = monome.GridBuffer(self.grid.width, self.grid.height)
-
-        # display steps
-        for x in range(self.grid.width):
-            for y in range(6):
-                buffer.led_level_set(x, y, self.step[y][x] * 11)
-
-        # update grid
-        buffer.render(self.grid)
+            self.draw()
 
     def on_grid_key(self, x, y, s):
         # toggle steps
-        if s == 1 and y < 6:
+        if s == 1 and y < canvasFloor:
             self.step[y][x] ^= 1
             self.draw()
 
-if __name__ == '__main__':
-    loop = asyncio.get_event_loop()
+    def draw(self):
+        buffer = monome.GridBuffer(width, height)
+        
+        # display steps
+        for x in range(width):
+            for y in range(canvasFloor):
+                buffer.led_level_set(x, y, self.step[y][x] * 11)
+
+        # update grid
+        if GridStudies.gridConnected:
+            buffer.render(self.grid)
+        
+async def main():
+    loop = asyncio.get_running_loop()
     grid_studies = GridStudies()
 
     def serialosc_device_added(id, type, port):
@@ -46,5 +70,8 @@ if __name__ == '__main__':
     serialosc = monome.SerialOsc()
     serialosc.device_added_event.add_handler(serialosc_device_added)
 
-    loop.run_until_complete(serialosc.connect())
-    loop.run_forever()
+    await serialosc.connect()
+    await loop.create_future()
+
+if __name__ == '__main__':
+    asyncio.run(main())

--- a/files/grid-studies-2-1.py
+++ b/files/grid-studies-2-1.py
@@ -1,3 +1,5 @@
+#! /usr/bin/env python3
+
 import asyncio
 import monome
 

--- a/files/grid-studies-2-1.py
+++ b/files/grid-studies-2-1.py
@@ -15,8 +15,8 @@ class GridStudies(monome.GridApp):
     def on_grid_ready(self):
         self.width = self.grid.width
         self.height = self.grid.height
-        self.connected = True
         self.sequencer_rows = self.height-2
+        self.connected = True
 
     # when grid is physically disconnected:
     def on_grid_disconnect(self, *args):

--- a/files/grid-studies-2-1.py
+++ b/files/grid-studies-2-1.py
@@ -5,20 +5,18 @@ import monome
 
 class GridStudies(monome.GridApp):
 
-    global gridConnected
-    global firstConnection
-
     def __init__(self):
         super().__init__()
     
     # track connection status:
     def connectGrid(state, self):
-        GridStudies.gridConnected = state
+        self.connected = state
         try:
-            GridStudies.firstConnection
-            GridStudies.firstConnection = False
+            self.firstConnection
+            self.firstConnection = False
         except:
-            GridStudies.firstConnection = True
+            self.firstConnection = True
+            # self.play() refers to a function defined further down:
             playTask = asyncio.create_task(self.play())
 
     # when grid is plugged in via USB:
@@ -31,7 +29,8 @@ class GridStudies(monome.GridApp):
         canvasFloor = height-2
 
         GridStudies.connectGrid(True, self)
-        if GridStudies.firstConnection:
+        if self.firstConnection:
+            # if this is the first connection, create a blank slate:
             self.step = [[0 for col in range(width)] for row in range(canvasFloor)]
 
     # when grid is physically disconnected:
@@ -58,7 +57,7 @@ class GridStudies(monome.GridApp):
                 buffer.led_level_set(x, y, self.step[y][x] * 11)
 
         # update grid
-        if GridStudies.gridConnected:
+        if self.connected:
             buffer.render(self.grid)
         
 async def main():

--- a/files/grid-studies-2-2.py
+++ b/files/grid-studies-2-2.py
@@ -16,8 +16,8 @@ class GridStudies(monome.GridApp):
     def on_grid_ready(self):
         self.width = self.grid.width
         self.height = self.grid.height
-        self.connected = True
         self.sequencer_rows = self.height-2
+        self.connected = True
 
     # when grid is physically disconnected:
     def on_grid_disconnect(self,*args):

--- a/files/grid-studies-2-2.py
+++ b/files/grid-studies-2-2.py
@@ -4,21 +4,18 @@ import asyncio
 import monome
 
 class GridStudies(monome.GridApp):
-    
-    global gridConnected
-    global firstConnection
 
     def __init__(self):
         super().__init__()
     
     # track connection status:
     def connectGrid(state, self):
-        GridStudies.gridConnected = state
+        self.connected = state
         try:
-            GridStudies.firstConnection
-            GridStudies.firstConnection = False
+            self.firstConnection
+            self.firstConnection = False
         except:
-            GridStudies.firstConnection = True
+            self.firstConnection = True
             playTask = asyncio.create_task(self.play())
 
     # when grid is plugged in via USB:
@@ -31,7 +28,7 @@ class GridStudies(monome.GridApp):
         canvasFloor = height-2
         
         GridStudies.connectGrid(True, self)
-        if GridStudies.firstConnection:
+        if self.firstConnection:
             self.step = [[0 for col in range(width)] for row in range(canvasFloor)]
             self.play_position = -1
 
@@ -47,7 +44,7 @@ class GridStudies(monome.GridApp):
             else:
                 self.play_position += 1
  
-            if GridStudies.gridConnected:
+            if self.connected:
                 self.draw()
 
     def draw(self):

--- a/files/grid-studies-2-2.py
+++ b/files/grid-studies-2-2.py
@@ -6,11 +6,11 @@ import monome
 class GridStudies(monome.GridApp):
     def __init__(self):
         super().__init__()
-
-    width = 0
-    height = 0
-    step = [[0 for col in range(16)] for row in range(16)]
-    play_position = -1
+        self.width = 0
+        self.height = 0
+        self.step = [[0 for col in range(16)] for row in range(16)]
+        self.play_position = -1
+        self.play_task = asyncio.ensure_future(self.play())
 
     # when grid is plugged in via USB:
     def on_grid_ready(self):
@@ -18,6 +18,7 @@ class GridStudies(monome.GridApp):
         self.height = self.grid.height
         self.sequencer_rows = self.height-2
         self.connected = True
+        self.draw()
 
     # when grid is physically disconnected:
     def on_grid_disconnect(self,*args):
@@ -26,12 +27,12 @@ class GridStudies(monome.GridApp):
     async def play(self):
         while True:
             await asyncio.sleep(0.1)
-            
+
             if self.play_position == self.width - 1:
                 self.play_position = 0
             else:
                 self.play_position += 1
- 
+
             if self.connected:
                 self.draw()
 
@@ -48,7 +49,7 @@ class GridStudies(monome.GridApp):
 
             for y in range(self.sequencer_rows):
                 buffer.led_level_set(x, y, self.step[y][x] * 11 + highlight)
-                
+
         # update grid
         buffer.render(self.grid)
 
@@ -68,8 +69,6 @@ async def main():
 
     serialosc = monome.SerialOsc()
     serialosc.device_added_event.add_handler(serialosc_device_added)
-
-    play_task = asyncio.create_task(grid_studies.play())
 
     await serialosc.connect()
     await loop.create_future()

--- a/files/grid-studies-2-2.py
+++ b/files/grid-studies-2-2.py
@@ -4,51 +4,77 @@ import asyncio
 import monome
 
 class GridStudies(monome.GridApp):
+    
+    global gridConnected
+    global firstConnection
+
     def __init__(self):
         super().__init__()
+    
+    # track connection status:
+    def connectGrid(state, self):
+        GridStudies.gridConnected = state
+        try:
+            GridStudies.firstConnection
+            GridStudies.firstConnection = False
+        except:
+            GridStudies.firstConnection = True
+            playTask = asyncio.create_task(self.play())
 
+    # when grid is plugged in via USB:
     def on_grid_ready(self):
-        self.step = [[0 for col in range(self.grid.width)] for row in range(6)]
-        self.play_position = 0
+        global width
+        width = self.grid.width
+        global height
+        height = self.grid.height
+        global canvasFloor
+        canvasFloor = height-2
+        
+        GridStudies.connectGrid(True, self)
+        if GridStudies.firstConnection:
+            self.step = [[0 for col in range(width)] for row in range(canvasFloor)]
+            self.play_position = -1
 
-        asyncio.async(self.play())
+    # when grid is physically disconnected:
+    def on_grid_disconnect(self,*args):
+        GridStudies.connectGrid(False, self)
 
     async def play(self):
         while True:
-            if self.play_position == self.grid.width - 1:
+            await asyncio.sleep(0.1)
+            if self.play_position == width - 1:
                 self.play_position = 0
             else:
                 self.play_position += 1
-
-            self.draw()
-
-            await  asyncio.sleep(0.1)
+ 
+            if GridStudies.gridConnected:
+                self.draw()
 
     def draw(self):
-        buffer = monome.GridBuffer(self.grid.width, self.grid.height)
+        buffer = monome.GridBuffer(width, height)
 
         # display steps
-        for x in range(self.grid.width):
+        for x in range(width):
             # highlight the play position
             if x == self.play_position:
                 highlight = 4
             else:
                 highlight = 0
 
-            for y in range(6):
+            for y in range(canvasFloor):
                 buffer.led_level_set(x, y, self.step[y][x] * 11 + highlight)
-
+                
         # update grid
         buffer.render(self.grid)
 
     def on_grid_key(self, x, y, s):
         # toggle steps
-        if s == 1 and y < 6:
+        if s == 1 and y < canvasFloor:
             self.step[y][x] ^= 1
             self.draw()
 
-if __name__ == '__main__':
-    loop = asyncio.get_event_loop()
+async def main():
+    loop = asyncio.get_running_loop()
     grid_studies = GridStudies()
 
     def serialosc_device_added(id, type, port):
@@ -58,5 +84,8 @@ if __name__ == '__main__':
     serialosc = monome.SerialOsc()
     serialosc.device_added_event.add_handler(serialosc_device_added)
 
-    loop.run_until_complete(serialosc.connect())
-    loop.run_forever()
+    await serialosc.connect()
+    await loop.create_future()
+
+if __name__ == '__main__':
+    asyncio.run(main())

--- a/files/grid-studies-2-3.py
+++ b/files/grid-studies-2-3.py
@@ -6,11 +6,11 @@ import monome
 class GridStudies(monome.GridApp):
     def __init__(self):
         super().__init__()
-
-    width = 0
-    height = 0
-    step = [[0 for col in range(16)] for row in range(16)]
-    play_position = -1
+        self.width = 0
+        self.height = 0
+        self.step = [[0 for col in range(16)] for row in range(16)]
+        self.play_position = -1
+        self.play_task = asyncio.ensure_future(self.play())
 
     # when grid is plugged in via USB:
     def on_grid_ready(self):
@@ -18,15 +18,16 @@ class GridStudies(monome.GridApp):
         self.height = self.grid.height
         self.sequencer_rows = self.height-2
         self.connected = True
+        self.draw()
 
     # when grid is physically disconnected:
     def on_grid_disconnect(self,*args):
         self.connected = False
-        
+
     async def play(self):
         while True:
             await asyncio.sleep(0.1)
-            
+
             if self.play_position == self.width - 1:
                 self.play_position = 0
             else:
@@ -84,8 +85,6 @@ async def main():
 
     serialosc = monome.SerialOsc()
     serialosc.device_added_event.add_handler(serialosc_device_added)
-
-    play_task = asyncio.create_task(grid_studies.play())
 
     await serialosc.connect()
     await loop.create_future()

--- a/files/grid-studies-2-3.py
+++ b/files/grid-studies-2-3.py
@@ -4,48 +4,36 @@ import asyncio
 import monome
 
 class GridStudies(monome.GridApp):
-
     def __init__(self):
         super().__init__()
-    
-    # track connection status:
-    def connectGrid(state, self):
-        self.connected = state
-        try:
-            self.firstConnection
-            self.firstConnection = False
-        except:
-            self.firstConnection = True
-            playTask = asyncio.create_task(self.play())
+
+    width = 0
+    height = 0
+    step = [[0 for col in range(16)] for row in range(16)]
+    play_position = -1
 
     # when grid is plugged in via USB:
     def on_grid_ready(self):
-        global width
-        width = self.grid.width
-        global height
-        height = self.grid.height
-        global canvasFloor
-        canvasFloor = height-2
-        
-        GridStudies.connectGrid(True, self)
-        if self.firstConnection:
-            self.step = [[0 for col in range(width)] for row in range(canvasFloor)]
-            self.play_position = -1
+        self.width = self.grid.width
+        self.height = self.grid.height
+        self.connected = True
+        self.sequencer_rows = self.height-2
 
     # when grid is physically disconnected:
     def on_grid_disconnect(self,*args):
-        GridStudies.connectGrid(False, self)
-
+        self.connected = False
+        
     async def play(self):
         while True:
             await asyncio.sleep(0.1)
-            if self.play_position == width - 1:
+            
+            if self.play_position == self.width - 1:
                 self.play_position = 0
             else:
                 self.play_position += 1
 
             # TRIGGER SOMETHING
-            for y in range(canvasFloor):
+            for y in range(self.sequencer_rows):
                 if self.step[y][self.play_position] == 1:
                     self.trigger(y)
 
@@ -56,33 +44,33 @@ class GridStudies(monome.GridApp):
         print("triggered", i)
 
     def draw(self):
-        buffer = monome.GridBuffer(width, height)
+        buffer = monome.GridBuffer(self.width, self.height)
 
         # display steps
-        for x in range(width):
+        for x in range(self.width):
             # highlight the play position
             if x == self.play_position:
                 highlight = 4
             else:
                 highlight = 0
 
-            for y in range(canvasFloor):
+            for y in range(self.sequencer_rows):
                 buffer.led_level_set(x, y, self.step[y][x] * 11 + highlight)
 
         # draw trigger bar and on-states
-        for x in range(width):
-            buffer.led_level_set(x, canvasFloor, 4)
+        for x in range(self.width):
+            buffer.led_level_set(x, self.sequencer_rows, 4)
 
-        for y in range(canvasFloor):
+        for y in range(self.sequencer_rows):
             if self.step[y][self.play_position] == 1:
-                buffer.led_level_set(self.play_position, canvasFloor, 15)
+                buffer.led_level_set(self.play_position, self.sequencer_rows, 15)
 
         # update grid
         buffer.render(self.grid)
 
     def on_grid_key(self, x, y, s):
         # toggle steps
-        if s == 1 and y < canvasFloor:
+        if s == 1 and y < self.sequencer_rows:
             self.step[y][x] ^= 1
             self.draw()
 
@@ -96,6 +84,8 @@ async def main():
 
     serialosc = monome.SerialOsc()
     serialosc.device_added_event.add_handler(serialosc_device_added)
+
+    play_task = asyncio.create_task(grid_studies.play())
 
     await serialosc.connect()
     await loop.create_future()

--- a/files/grid-studies-2-3.py
+++ b/files/grid-studies-2-3.py
@@ -4,66 +4,92 @@ import asyncio
 import monome
 
 class GridStudies(monome.GridApp):
+
+    global gridConnected
+    global firstConnection
+
     def __init__(self):
         super().__init__()
+    
+    # track connection status:
+    def connectGrid(state, self):
+        GridStudies.gridConnected = state
+        try:
+            GridStudies.firstConnection
+            GridStudies.firstConnection = False
+        except:
+            GridStudies.firstConnection = True
+            playTask = asyncio.create_task(self.play())
 
+    # when grid is plugged in via USB:
     def on_grid_ready(self):
-        self.step = [[0 for col in range(self.grid.width)] for row in range(6)]
-        self.play_position = 0
+        global width
+        width = self.grid.width
+        global height
+        height = self.grid.height
+        global canvasFloor
+        canvasFloor = height-2
+        
+        GridStudies.connectGrid(True, self)
+        if GridStudies.firstConnection:
+            self.step = [[0 for col in range(width)] for row in range(canvasFloor)]
+            self.play_position = -1
 
-        asyncio.async(self.play())
+    # when grid is physically disconnected:
+    def on_grid_disconnect(self,*args):
+        GridStudies.connectGrid(False, self)
 
     async def play(self):
         while True:
-            if self.play_position == self.grid.width - 1:
+            await asyncio.sleep(0.1)
+            if self.play_position == width - 1:
                 self.play_position = 0
             else:
                 self.play_position += 1
 
             # TRIGGER SOMETHING
-            for y in range(6):
+            for y in range(canvasFloor):
                 if self.step[y][self.play_position] == 1:
                     self.trigger(y)
 
-            self.draw()
-
-            await asyncio.sleep(0.1)
+            if GridStudies.gridConnected:
+                self.draw()
 
     def trigger(self, i):
         print("triggered", i)
 
     def draw(self):
-        buffer = monome.GridBuffer(self.grid.width, self.grid.height)
+        buffer = monome.GridBuffer(width, height)
 
         # display steps
-        for x in range(self.grid.width):
+        for x in range(width):
             # highlight the play position
             if x == self.play_position:
                 highlight = 4
             else:
                 highlight = 0
 
-            for y in range(6):
+            for y in range(canvasFloor):
                 buffer.led_level_set(x, y, self.step[y][x] * 11 + highlight)
 
         # draw trigger bar and on-states
-        for x in range(self.grid.width):
-            buffer.led_level_set(x, 6, 4)
+        for x in range(width):
+            buffer.led_level_set(x, canvasFloor, 4)
 
-        for y in range(6):
+        for y in range(canvasFloor):
             if self.step[y][self.play_position] == 1:
-                buffer.led_level_set(self.play_position, 6, 15)
+                buffer.led_level_set(self.play_position, canvasFloor, 15)
 
         # update grid
         buffer.render(self.grid)
 
     def on_grid_key(self, x, y, s):
         # toggle steps
-        if s == 1 and y < 6:
+        if s == 1 and y < canvasFloor:
             self.step[y][x] ^= 1
             self.draw()
 
-if __name__ == '__main__':
+async def main():
     loop = asyncio.get_event_loop()
     grid_studies = GridStudies()
 
@@ -74,5 +100,8 @@ if __name__ == '__main__':
     serialosc = monome.SerialOsc()
     serialosc.device_added_event.add_handler(serialosc_device_added)
 
-    loop.run_until_complete(serialosc.connect())
-    loop.run_forever()
+    await serialosc.connect()
+    await loop.create_future()
+
+if __name__ == '__main__':
+    asyncio.run(main())

--- a/files/grid-studies-2-3.py
+++ b/files/grid-studies-2-3.py
@@ -16,8 +16,8 @@ class GridStudies(monome.GridApp):
     def on_grid_ready(self):
         self.width = self.grid.width
         self.height = self.grid.height
-        self.connected = True
         self.sequencer_rows = self.height-2
+        self.connected = True
 
     # when grid is physically disconnected:
     def on_grid_disconnect(self,*args):

--- a/files/grid-studies-2-3.py
+++ b/files/grid-studies-2-3.py
@@ -5,20 +5,17 @@ import monome
 
 class GridStudies(monome.GridApp):
 
-    global gridConnected
-    global firstConnection
-
     def __init__(self):
         super().__init__()
     
     # track connection status:
     def connectGrid(state, self):
-        GridStudies.gridConnected = state
+        self.connected = state
         try:
-            GridStudies.firstConnection
-            GridStudies.firstConnection = False
+            self.firstConnection
+            self.firstConnection = False
         except:
-            GridStudies.firstConnection = True
+            self.firstConnection = True
             playTask = asyncio.create_task(self.play())
 
     # when grid is plugged in via USB:
@@ -31,7 +28,7 @@ class GridStudies(monome.GridApp):
         canvasFloor = height-2
         
         GridStudies.connectGrid(True, self)
-        if GridStudies.firstConnection:
+        if self.firstConnection:
             self.step = [[0 for col in range(width)] for row in range(canvasFloor)]
             self.play_position = -1
 
@@ -52,7 +49,7 @@ class GridStudies(monome.GridApp):
                 if self.step[y][self.play_position] == 1:
                     self.trigger(y)
 
-            if GridStudies.gridConnected:
+            if self.connected:
                 self.draw()
 
     def trigger(self, i):

--- a/files/grid-studies-2-4.py
+++ b/files/grid-studies-2-4.py
@@ -4,39 +4,26 @@ import asyncio
 import monome
 
 class GridStudies(monome.GridApp):
-
     def __init__(self):
         super().__init__()
-    
-    # track connection status:
-    def connectGrid(state, self):
-        self.connected = state
-        try:
-            self.firstConnection
-            self.firstConnection = False
-        except:
-            self.firstConnection = True
-            playTask = asyncio.create_task(self.play())
+
+    width = 0
+    height = 0
+    step = [[0 for col in range(16)] for row in range(16)]
+    play_position = -1
+    next_position = -1
+    cutting = False
 
     # when grid is plugged in via USB:
     def on_grid_ready(self):
-        global width
-        width = self.grid.width
-        global height
-        height = self.grid.height
-        global canvasFloor
-        canvasFloor = height-2
-        
-        GridStudies.connectGrid(True, self)
-        if self.firstConnection:      
-            self.step = [[0 for col in range(width)] for row in range(canvasFloor)]
-            self.play_position = -1
-            self.next_position = -1
-            self.cutting = False
+        self.width = self.grid.width
+        self.height = self.grid.height
+        self.connected = True
+        self.sequencer_rows = self.height-2
 
     # when grid is physically disconnected:
     def on_grid_disconnect(self,*args):
-        GridStudies.connectGrid(False, self)
+        self.connected = False
 
     async def play(self):
         while True:
@@ -44,13 +31,13 @@ class GridStudies(monome.GridApp):
             
             if self.cutting:
                 self.play_position = self.next_position
-            elif self.play_position == width - 1:
+            elif self.play_position == self.width - 1:
                 self.play_position = 0
             else:
                 self.play_position += 1
 
             # TRIGGER SOMETHING
-            for y in range(canvasFloor):
+            for y in range(self.sequencer_rows):
                 if self.step[y][self.play_position] == 1:
                     self.trigger(y)
 
@@ -63,40 +50,40 @@ class GridStudies(monome.GridApp):
         print("triggered", i)
 
     def draw(self):
-        buffer = monome.GridBuffer(width, height)
+        buffer = monome.GridBuffer(self.width, self.height)
 
         # display steps
-        for x in range(width):
+        for x in range(self.width):
             # highlight the play position
             if x == self.play_position:
                 highlight = 4
             else:
                 highlight = 0
 
-            for y in range(canvasFloor):
+            for y in range(self.sequencer_rows):
                 buffer.led_level_set(x, y, self.step[y][x] * 11 + highlight)
 
         # draw trigger bar and on-states
-        for x in range(width):
-            buffer.led_level_set(x, canvasFloor, 4)
+        for x in range(self.width):
+            buffer.led_level_set(x, self.sequencer_rows, 4)
 
-        for y in range(canvasFloor):
+        for y in range(self.sequencer_rows):
             if self.step[y][self.play_position] == 1:
-                buffer.led_level_set(self.play_position, canvasFloor, 15)
+                buffer.led_level_set(self.play_position, self.sequencer_rows, 15)
 
         # draw play position
-        buffer.led_level_set(self.play_position, canvasFloor+1, 15)
+        buffer.led_level_set(self.play_position, self.sequencer_rows+1, 15)
 
         # update grid
         buffer.render(self.grid)
 
     def on_grid_key(self, x, y, s):
         # toggle steps
-        if s == 1 and y < canvasFloor:
+        if s == 1 and y < self.sequencer_rows:
             self.step[y][x] ^= 1
             self.draw()
         # cut
-        elif y == height-1: # want 0-index!
+        elif y == self.height-1: # want 0-index!
             # cut
             if s == 1:
                 self.cutting = True
@@ -112,6 +99,8 @@ async def main():
 
     serialosc = monome.SerialOsc()
     serialosc.device_added_event.add_handler(serialosc_device_added)
+
+    play_task = asyncio.create_task(grid_studies.play())
 
     await serialosc.connect()
     await loop.create_future()

--- a/files/grid-studies-2-4.py
+++ b/files/grid-studies-2-4.py
@@ -18,8 +18,8 @@ class GridStudies(monome.GridApp):
     def on_grid_ready(self):
         self.width = self.grid.width
         self.height = self.grid.height
-        self.connected = True
         self.sequencer_rows = self.height-2
+        self.connected = True
 
     # when grid is physically disconnected:
     def on_grid_disconnect(self,*args):

--- a/files/grid-studies-2-4.py
+++ b/files/grid-studies-2-4.py
@@ -4,81 +4,108 @@ import asyncio
 import monome
 
 class GridStudies(monome.GridApp):
+
+    global gridConnected
+    global firstConnection
+
     def __init__(self):
         super().__init__()
+    
+    # track connection status:
+    def connectGrid(state, self):
+        GridStudies.gridConnected = state
+        try:
+            GridStudies.firstConnection
+            GridStudies.firstConnection = False
+        except:
+            GridStudies.firstConnection = True
+            playTask = asyncio.create_task(self.play())
 
+    # when grid is plugged in via USB:
     def on_grid_ready(self):
-        self.step = [[0 for col in range(self.grid.width)] for row in range(6)]
-        self.play_position = 0
-        self.next_position = 0
-        self.cutting = False
+        global width
+        width = self.grid.width
+        global height
+        height = self.grid.height
+        global canvasFloor
+        canvasFloor = height-2
+        
+        GridStudies.connectGrid(True, self)
+        if GridStudies.firstConnection:      
+            self.step = [[0 for col in range(width)] for row in range(canvasFloor)]
+            self.play_position = -1
+            self.next_position = -1
+            self.cutting = False
 
-        asyncio.async(self.play())
+    # when grid is physically disconnected:
+    def on_grid_disconnect(self,*args):
+        GridStudies.connectGrid(False, self)
 
     async def play(self):
         while True:
+            await asyncio.sleep(0.1)
+            
             if self.cutting:
                 self.play_position = self.next_position
-            elif self.play_position == self.grid.width - 1:
+            elif self.play_position == width - 1:
                 self.play_position = 0
             else:
                 self.play_position += 1
 
             # TRIGGER SOMETHING
-            for y in range(6):
+            for y in range(canvasFloor):
                 if self.step[y][self.play_position] == 1:
                     self.trigger(y)
 
             self.cutting = False
-            self.draw()
 
-            await asyncio.sleep(0.1)
+            if GridStudies.gridConnected:
+                self.draw()
 
     def trigger(self, i):
         print("triggered", i)
 
     def draw(self):
-        buffer = monome.GridBuffer(self.grid.width, self.grid.height)
+        buffer = monome.GridBuffer(width, height)
 
         # display steps
-        for x in range(self.grid.width):
+        for x in range(width):
             # highlight the play position
             if x == self.play_position:
                 highlight = 4
             else:
                 highlight = 0
 
-            for y in range(6):
+            for y in range(canvasFloor):
                 buffer.led_level_set(x, y, self.step[y][x] * 11 + highlight)
 
         # draw trigger bar and on-states
-        for x in range(self.grid.width):
-            buffer.led_level_set(x, 6, 4)
+        for x in range(width):
+            buffer.led_level_set(x, canvasFloor, 4)
 
-        for y in range(6):
+        for y in range(canvasFloor):
             if self.step[y][self.play_position] == 1:
-                buffer.led_level_set(self.play_position, 6, 15)
+                buffer.led_level_set(self.play_position, canvasFloor, 15)
 
         # draw play position
-        buffer.led_level_set(self.play_position, 7, 15)
+        buffer.led_level_set(self.play_position, canvasFloor+1, 15)
 
         # update grid
         buffer.render(self.grid)
 
     def on_grid_key(self, x, y, s):
         # toggle steps
-        if s == 1 and y < 6:
+        if s == 1 and y < canvasFloor:
             self.step[y][x] ^= 1
             self.draw()
         # cut
-        elif y == 7:
+        elif y == height-1: # want 0-index!
             # cut
             if s == 1:
                 self.cutting = True
                 self.next_position = x
-                self.key_last = x
 
-if __name__ == '__main__':
+async def main():
     loop = asyncio.get_event_loop()
     grid_studies = GridStudies()
 
@@ -89,5 +116,8 @@ if __name__ == '__main__':
     serialosc = monome.SerialOsc()
     serialosc.device_added_event.add_handler(serialosc_device_added)
 
-    loop.run_until_complete(serialosc.connect())
-    loop.run_forever()
+    await serialosc.connect()
+    await loop.create_future()
+
+if __name__ == '__main__':
+    asyncio.run(main())

--- a/files/grid-studies-2-4.py
+++ b/files/grid-studies-2-4.py
@@ -5,20 +5,17 @@ import monome
 
 class GridStudies(monome.GridApp):
 
-    global gridConnected
-    global firstConnection
-
     def __init__(self):
         super().__init__()
     
     # track connection status:
     def connectGrid(state, self):
-        GridStudies.gridConnected = state
+        self.connected = state
         try:
-            GridStudies.firstConnection
-            GridStudies.firstConnection = False
+            self.firstConnection
+            self.firstConnection = False
         except:
-            GridStudies.firstConnection = True
+            self.firstConnection = True
             playTask = asyncio.create_task(self.play())
 
     # when grid is plugged in via USB:
@@ -31,7 +28,7 @@ class GridStudies(monome.GridApp):
         canvasFloor = height-2
         
         GridStudies.connectGrid(True, self)
-        if GridStudies.firstConnection:      
+        if self.firstConnection:      
             self.step = [[0 for col in range(width)] for row in range(canvasFloor)]
             self.play_position = -1
             self.next_position = -1
@@ -59,7 +56,7 @@ class GridStudies(monome.GridApp):
 
             self.cutting = False
 
-            if GridStudies.gridConnected:
+            if self.connected:
                 self.draw()
 
     def trigger(self, i):

--- a/files/grid-studies-2-4.py
+++ b/files/grid-studies-2-4.py
@@ -6,13 +6,13 @@ import monome
 class GridStudies(monome.GridApp):
     def __init__(self):
         super().__init__()
-
-    width = 0
-    height = 0
-    step = [[0 for col in range(16)] for row in range(16)]
-    play_position = -1
-    next_position = -1
-    cutting = False
+        self.width = 0
+        self.height = 0
+        self.step = [[0 for col in range(16)] for row in range(16)]
+        self.play_position = -1
+        self.next_position = -1
+        self.cutting = False
+        self.play_task = asyncio.ensure_future(self.play())
 
     # when grid is plugged in via USB:
     def on_grid_ready(self):
@@ -20,6 +20,7 @@ class GridStudies(monome.GridApp):
         self.height = self.grid.height
         self.sequencer_rows = self.height-2
         self.connected = True
+        self.draw()
 
     # when grid is physically disconnected:
     def on_grid_disconnect(self,*args):
@@ -28,7 +29,7 @@ class GridStudies(monome.GridApp):
     async def play(self):
         while True:
             await asyncio.sleep(0.1)
-            
+
             if self.cutting:
                 self.play_position = self.next_position
             elif self.play_position == self.width - 1:
@@ -99,8 +100,6 @@ async def main():
 
     serialosc = monome.SerialOsc()
     serialosc.device_added_event.add_handler(serialosc_device_added)
-
-    play_task = asyncio.create_task(grid_studies.play())
 
     await serialosc.connect()
     await loop.create_future()

--- a/files/grid-studies-2-5.py
+++ b/files/grid-studies-2-5.py
@@ -5,20 +5,17 @@ import monome
 
 class GridStudies(monome.GridApp):
 
-    global gridConnected
-    global firstConnection
-
     def __init__(self):
         super().__init__()
     
     # track connection status:
     def connectGrid(state, self):
-        GridStudies.gridConnected = state
+        self.connected = state
         try:
-            GridStudies.firstConnection
-            GridStudies.firstConnection = False
+            self.firstConnection
+            self.firstConnection = False
         except:
-            GridStudies.firstConnection = True
+            self.firstConnection = True
             playTask = asyncio.create_task(self.play())
 
     # when grid is plugged in via USB:
@@ -31,7 +28,7 @@ class GridStudies(monome.GridApp):
         canvasFloor = height-2
         
         GridStudies.connectGrid(True, self)
-        if GridStudies.firstConnection:      
+        if self.firstConnection:      
             self.step = [[0 for col in range(width)] for row in range(canvasFloor)]
             self.play_position = -1
             self.next_position = -1
@@ -63,7 +60,7 @@ class GridStudies(monome.GridApp):
 
             self.cutting = False
 
-            if GridStudies.gridConnected:
+            if self.connected:
                 self.draw()
 
     def trigger(self, i):

--- a/files/grid-studies-2-5.py
+++ b/files/grid-studies-2-5.py
@@ -6,24 +6,25 @@ import monome
 class GridStudies(monome.GridApp):
     def __init__(self):
         super().__init__()
+        self.width = 0
+        self.height = 0
+        self.step = [[0 for col in range(16)] for row in range(16)]
+        self.play_position = -1
+        self.next_position = -1
+        self.cutting = False
+        self.loop_start = 0
+        self.loop_end = self.width - 1
+        self.keys_held = 0
+        self.key_last = 0
+        self.play_task = asyncio.ensure_future(self.play())
 
-    width = 0
-    height = 0
-    step = [[0 for col in range(16)] for row in range(16)]
-    play_position = -1
-    next_position = -1
-    cutting = False
-    loop_start = 0
-    loop_end = width - 1
-    keys_held = 0
-    key_last = 0
-    
     # when grid is plugged in via USB:
     def on_grid_ready(self):
         self.width = self.grid.width
         self.height = self.grid.height
         self.sequencer_rows = self.height-2
         self.connected = True
+        self.draw()
 
     def on_grid_disconnect(self,*args):
         self.connected = False
@@ -31,7 +32,7 @@ class GridStudies(monome.GridApp):
     async def play(self):
         while True:
             await asyncio.sleep(0.1)
-            
+
             if self.cutting:
                 self.play_position = self.next_position
             elif self.play_position == self.width - 1:
@@ -110,8 +111,6 @@ async def main():
 
     serialosc = monome.SerialOsc()
     serialosc.device_added_event.add_handler(serialosc_device_added)
-
-    play_task = asyncio.create_task(grid_studies.play())
 
     await serialosc.connect()
     await loop.create_future()

--- a/files/grid-studies-2-5.py
+++ b/files/grid-studies-2-5.py
@@ -22,8 +22,8 @@ class GridStudies(monome.GridApp):
     def on_grid_ready(self):
         self.width = self.grid.width
         self.height = self.grid.height
-        self.connected = True
         self.sequencer_rows = self.height-2
+        self.connected = True
 
     def on_grid_disconnect(self,*args):
         self.connected = False

--- a/files/grid-studies-2-5.py
+++ b/files/grid-studies-2-5.py
@@ -4,49 +4,37 @@ import asyncio
 import monome
 
 class GridStudies(monome.GridApp):
-
     def __init__(self):
         super().__init__()
-    
-    # track connection status:
-    def connectGrid(state, self):
-        self.connected = state
-        try:
-            self.firstConnection
-            self.firstConnection = False
-        except:
-            self.firstConnection = True
-            playTask = asyncio.create_task(self.play())
 
+    width = 0
+    height = 0
+    step = [[0 for col in range(16)] for row in range(16)]
+    play_position = -1
+    next_position = -1
+    cutting = False
+    loop_start = 0
+    loop_end = width - 1
+    keys_held = 0
+    key_last = 0
+    
     # when grid is plugged in via USB:
     def on_grid_ready(self):
-        global width
-        width = self.grid.width
-        global height
-        height = self.grid.height
-        global canvasFloor
-        canvasFloor = height-2
-        
-        GridStudies.connectGrid(True, self)
-        if self.firstConnection:      
-            self.step = [[0 for col in range(width)] for row in range(canvasFloor)]
-            self.play_position = -1
-            self.next_position = -1
-            self.cutting = False
-            self.loop_start = 0
-            self.loop_end = width - 1
-            self.keys_held = 0
-            self.key_last = 0
+        self.width = self.grid.width
+        self.height = self.grid.height
+        self.connected = True
+        self.sequencer_rows = self.height-2
 
     def on_grid_disconnect(self,*args):
-        GridStudies.connectGrid(False, self)
+        self.connected = False
 
     async def play(self):
         while True:
             await asyncio.sleep(0.1)
+            
             if self.cutting:
                 self.play_position = self.next_position
-            elif self.play_position == width - 1:
+            elif self.play_position == self.width - 1:
                 self.play_position = 0
             elif self.play_position == self.loop_end:
                 self.play_position = self.loop_start
@@ -54,7 +42,7 @@ class GridStudies(monome.GridApp):
                 self.play_position += 1
 
             # TRIGGER SOMETHING
-            for y in range(canvasFloor):
+            for y in range(self.sequencer_rows):
                 if self.step[y][self.play_position] == 1:
                     self.trigger(y)
 
@@ -67,40 +55,40 @@ class GridStudies(monome.GridApp):
         print("triggered", i)
 
     def draw(self):
-        buffer = monome.GridBuffer(width, height)
+        buffer = monome.GridBuffer(self.width, self.height)
 
         # display steps
-        for x in range(width):
+        for x in range(self.width):
             # highlight the play position
             if x == self.play_position:
                 highlight = 4
             else:
                 highlight = 0
 
-            for y in range(canvasFloor):
+            for y in range(self.sequencer_rows):
                 buffer.led_level_set(x, y, self.step[y][x] * 11 + highlight)
 
         # draw trigger bar and on-states
-        for x in range(width):
-            buffer.led_level_set(x, canvasFloor, 4)
+        for x in range(self.width):
+            buffer.led_level_set(x, self.sequencer_rows, 4)
 
-        for y in range(canvasFloor):
+        for y in range(self.sequencer_rows):
             if self.step[y][self.play_position] == 1:
-                buffer.led_level_set(self.play_position, canvasFloor, 15)
+                buffer.led_level_set(self.play_position, self.sequencer_rows, 15)
 
         # draw play position
-        buffer.led_level_set(self.play_position, height-1, 15)
+        buffer.led_level_set(self.play_position, self.height-1, 15)
 
         # update grid
         buffer.render(self.grid)
 
     def on_grid_key(self, x, y, s):
         # toggle steps
-        if s == 1 and y < canvasFloor:
+        if s == 1 and y < self.sequencer_rows:
             self.step[y][x] ^= 1
             self.draw()
         # cut and loop
-        elif y == height-1:
+        elif y == self.height-1:
             self.keys_held = self.keys_held + (s * 2) - 1
             # cut
             if s == 1 and self.keys_held == 1:
@@ -122,6 +110,8 @@ async def main():
 
     serialosc = monome.SerialOsc()
     serialosc.device_added_event.add_handler(serialosc_device_added)
+
+    play_task = asyncio.create_task(grid_studies.play())
 
     await serialosc.connect()
     await loop.create_future()


### PR DESCRIPTION
in an effort to update the Grid Studies series, i went through the Python study files to reflect changes / deprecations for Python 3.11 (these were last updated/written for 3.5), as well as to anticipate new questions about scripting techniques based on expectations from norns.
namely:

- if the grid is disconnected during a script's run, the 'action' of the script should continue without error
- variables managed by the grid should persist if the grid connection is lost (like when changing applications or hot-swapping to another device)

i also wanted to demonstrate scripting that adapts to the size of the connected grid, by avoiding hard-coding stuff like 'row 7 displays triggers' in favor of 'the second-to-last row displays triggers'.

this also corresponds to an [update of the study text](https://github.com/monome/docs/blob/python-2023/grid/studies/python/index.md). i'm **for sure** a Python novice, so hopefully the text presents the pedagogical _intent_ of the changes, towards which i'd love your feedback / suggestions for alternative methods of achieving the same results in clearer code!

tytyty! <333